### PR TITLE
Add product categories

### DIFF
--- a/CRM/add_product_action.php
+++ b/CRM/add_product_action.php
@@ -1,0 +1,60 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+header('Content-Type: application/json');
+$response = ['success' => false, 'message' => 'Errore sconosciuto'];
+
+if ($_SERVER["REQUEST_METHOD"] !== 'POST') {
+    $response['message'] = 'Metodo di richiesta non valido.';
+    echo json_encode($response);
+    exit;
+}
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || ($_SESSION['ruolo'] ?? '') !== 'admin') {
+    $response['message'] = 'Accesso non autorizzato.';
+    echo json_encode($response);
+    exit;
+}
+
+$nome = trim($_POST['nome_prodotto'] ?? '');
+$categoria_id = isset($_POST['categoria_id']) ? (int)$_POST['categoria_id'] : 1;
+if ($nome === '') {
+    $response['message'] = 'Nome prodotto mancante.';
+    echo json_encode($response);
+    exit;
+}
+
+$conn = isset($db_port) ? new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port) : new mysqli($db_host, $db_user, $db_pass, $db_name);
+if ($conn->connect_error) {
+    $response['message'] = 'Errore connessione database.';
+    echo json_encode($response);
+    exit;
+}
+
+$stmt = $conn->prepare("INSERT INTO catalogo_prodotti (nome, categoria_id) VALUES (?, ?)");
+if (!$stmt) {
+    $response['message'] = 'Errore preparazione statement.';
+    echo json_encode($response);
+    $conn->close();
+    exit;
+}
+
+$stmt->bind_param("si", $nome, $categoria_id);
+if ($stmt->execute()) {
+    $response['success'] = true;
+    $response['message'] = 'Prodotto aggiunto con successo';
+    $response['id'] = $conn->insert_id;
+} else {
+    if ($conn->errno == 1062) {
+        $response['message'] = 'Prodotto già esistente.';
+    } else {
+        $response['message'] = 'Errore durante l\'inserimento.';
+    }
+}
+$stmt->close();
+$conn->close();
+
+echo json_encode($response);
+exit;
+?>

--- a/CRM/dashboard.php
+++ b/CRM/dashboard.php
@@ -128,6 +128,10 @@ $user_role_display = htmlspecialchars(isset($_SESSION['ruolo']) ? $_SESSION['ruo
                     <div class="tool-card-header"><div class="tool-card-icon">👤</div><h3 class="tool-card-title">Gestione Utenze</h3></div>
                     <p class="tool-card-description">Crea, visualizza e modifica gli utenti del sistema.</p>
                 </a>
+                <a href="gestioneprodotti.php" class="tool-card">
+                    <div class="tool-card-header"><div class="tool-card-icon">📦</div><h3 class="tool-card-title">Gestione Prodotti</h3></div>
+                    <p class="tool-card-description">Aggiungi nuovi prodotti al catalogo.</p>
+                </a>
             </div>
         <?php endif; ?>
 

--- a/CRM/db_deploy.sql
+++ b/CRM/db_deploy.sql
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS `ordini` (
   `nome_richiedente` varchar(150) NOT NULL,
   `centro_costo` varchar(100) NOT NULL,
   `stato_ordine` varchar(50) NOT NULL DEFAULT 'Inviato',
+  `consenti_modifica` tinyint(1) NOT NULL DEFAULT 0,
   `fattura_file` varchar(255) DEFAULT NULL,
   `data_creazione` timestamp NOT NULL DEFAULT current_timestamp(),
   `data_ultima_modifica` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
@@ -126,6 +127,22 @@ CREATE TABLE IF NOT EXISTS `ordini_chat` (
   CONSTRAINT `ordini_chat_ibfk_2` FOREIGN KEY (`id_utente`) REFERENCES `utenti` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- ------------------------------------------------------------------
+-- Tabella ordini_modifiche: traccia delle modifiche apportate dagli utenti
+-- ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `ordini_modifiche` (
+  `id_modifica` int(11) NOT NULL AUTO_INCREMENT,
+  `id_ordine` int(11) NOT NULL,
+  `id_utente` int(11) NOT NULL,
+  `prima` text NOT NULL,
+  `dopo` text NOT NULL,
+  `data_modifica` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id_modifica`),
+  KEY `idx_modifica_ordine` (`id_ordine`),
+  CONSTRAINT `modifiche_ordine_ibfk_1` FOREIGN KEY (`id_ordine`) REFERENCES `ordini` (`id_ordine`) ON DELETE CASCADE,
+  CONSTRAINT `modifiche_utente_ibfk_2` FOREIGN KEY (`id_utente`) REFERENCES `utenti` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
 -- Dump della struttura di tabella gruppo_vitolo_db.utenti
 CREATE TABLE IF NOT EXISTS `utenti` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -142,8 +159,39 @@ CREATE TABLE IF NOT EXISTS `utenti` (
 
 -- Dump dei dati della tabella gruppo_vitolo_db.utenti: ~2 rows (circa)
 INSERT INTO `utenti` (`id`, `username`, `email`, `nome`, `password_hash`, `ruolo`, `data_creazione`) VALUES
-	(1, 'admin', 'admin@gruppovitolo.example.com', 'admin', '$2y$10$9RMP49bT0CRS9I.MXuIa7ek2SHfovBVWezAMjYvXTyz5oq.2EV3NO', 'admin', '2025-06-06 07:36:44'),
-	(2, 'users', '', 'users', '$2y$10$jCb4tU2C6hc99e4gFJUCTePCTwJhtK7BuK1lF046bJrscFDw4ikVi', 'user', '2025-06-06 07:36:44');
+        (1, 'admin', 'admin@gruppovitolo.example.com', 'admin', '$2y$10$9RMP49bT0CRS9I.MXuIa7ek2SHfovBVWezAMjYvXTyz5oq.2EV3NO', 'admin', '2025-06-06 07:36:44'),
+        (2, 'users', '', 'users', '$2y$10$jCb4tU2C6hc99e4gFJUCTePCTwJhtK7BuK1lF046bJrscFDw4ikVi', 'user', '2025-06-06 07:36:44');
+
+-- ------------------------------------------------------------------
+-- Tabella categorie_prodotti: raggruppa i prodotti per categoria
+-- ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `categorie_prodotti` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nome` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_nome_categoria` (`nome`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+INSERT INTO `categorie_prodotti` (`id`, `nome`) VALUES
+        (1, 'Generale');
+
+-- ------------------------------------------------------------------
+-- Tabella catalogo_prodotti: elenco di prodotti disponibili per l'app
+-- ------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `catalogo_prodotti` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nome` varchar(255) NOT NULL,
+  `categoria_id` int(11) NOT NULL DEFAULT 1,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_nome` (`nome`),
+  KEY `idx_categoria` (`categoria_id`),
+  CONSTRAINT `catalogo_categoria_fk` FOREIGN KEY (`categoria_id`) REFERENCES `categorie_prodotti` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- Esempio di prodotti iniziali
+INSERT INTO `catalogo_prodotti` (`id`, `nome`) VALUES
+        (1, 'Carta A4'),
+        (2, 'Toner Stampante');
 
 /*!40103 SET TIME_ZONE=IFNULL(@OLD_TIME_ZONE, 'system') */;
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;

--- a/CRM/edit_order.php
+++ b/CRM/edit_order.php
@@ -3,16 +3,52 @@ session_start();
 
 require_once 'db_config.php';
 
-// Verifica se l'utente è loggato, altrimenti reindirizza alla pagina di login
-if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
-    header("Location: login.php");
+// Verifica login
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || !isset($_SESSION['user_id'])) {
+    header('Location: login.php');
     exit;
 }
 
-// Preparazione dati per il form
-$current_date = date('d/m/Y');
-$richiedente_nome = (!empty($_SESSION['user_fullname'])) ? htmlspecialchars($_SESSION['user_fullname']) : htmlspecialchars($_SESSION['username']);
+$id_ordine = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+if ($conn->connect_error || !$id_ordine) {
+    header('Location: i_miei_ordini.php?edit=error');
+    exit;
+}
+
+$stmt_info = $conn->prepare('SELECT nome_richiedente, centro_costo, consenti_modifica, id_utente_richiedente FROM ordini WHERE id_ordine = ?');
+$stmt_info->bind_param('i', $id_ordine);
+$stmt_info->execute();
+$info = $stmt_info->get_result()->fetch_assoc();
+$stmt_info->close();
+
+if (!$info || $info['id_utente_richiedente'] != $_SESSION['user_id'] || $info['consenti_modifica'] != 1) {
+    $conn->close();
+    header('Location: i_miei_ordini.php?edit=error');
+    exit;
+}
+
+$richiedente_nome = htmlspecialchars($info['nome_richiedente']);
 $id_utente_richiedente = $_SESSION['user_id'];
+$centro_costo_selezionato = htmlspecialchars($info['centro_costo']);
+
+// Carica prodotti esistenti
+$prodotti_esistenti = [];
+$stmt_det = $conn->prepare('SELECT nome_prodotto, quantita, unita_misura, note_prodotto FROM dettagli_ordine WHERE id_ordine = ? ORDER BY id_dettaglio_ordine');
+$stmt_det->bind_param('i', $id_ordine);
+$stmt_det->execute();
+$res_det = $stmt_det->get_result();
+while ($row = $res_det->fetch_assoc()) {
+    $prodotti_esistenti[] = [
+        'name' => $row['nome_prodotto'],
+        'quantity' => (int)$row['quantita'],
+        'unit' => $row['unita_misura'],
+        'notes' => $row['note_prodotto'] ?? ''
+    ];
+}
+$stmt_det->close();
+$conn->close();
+$current_date = date('d/m/Y');
 
 // Opzioni per i dropdown
 $centri_di_costo = [
@@ -80,7 +116,7 @@ error_log("--- [{$timestamp}] Accesso a form_page.php UTENTE: " . htmlspecialcha
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Modulo Richiesta Acquisti - Gruppo Vitolo</title>
+    <title>Modifica Richiesta - Gruppo Vitolo</title>
     <link rel="stylesheet" href="style.css"> 
     <style>
         html {
@@ -176,7 +212,7 @@ error_log("--- [{$timestamp}] Accesso a form_page.php UTENTE: " . htmlspecialcha
                 <a href="dashboard.php"> <img src="logo.png" alt="Logo Gruppo Vitolo" class="logo">
                 </a>
                 <div class="header-titles">
-                    <h1>Modulo Richiesta Acquisti</h1>
+                    <h1>Modifica Richiesta</h1>
                     <h2>Gruppo Vitolo</h2>
                 </div>
             </div>
@@ -198,7 +234,8 @@ error_log("--- [{$timestamp}] Accesso a form_page.php UTENTE: " . htmlspecialcha
                 </div>
             <?php endif; ?>
 
-            <form id="main-request-form" action="submit_order_action.php" method="POST">
+            <form id="main-request-form" action="update_order_action.php" method="POST">
+                <input type="hidden" name="id_ordine" value="<?php echo $id_ordine; ?>">
                 <div class="form-row">
                     <div class="form-group">
                         <label for="data_richiesta_display">Data Richiesta:</label>
@@ -217,7 +254,7 @@ error_log("--- [{$timestamp}] Accesso a form_page.php UTENTE: " . htmlspecialcha
                         <select id="centro_costo" name="centro_costo" required>
                             <option value="">Seleziona un centro di costo...</option>
                             <?php foreach ($centri_di_costo as $cdc): ?>
-                                <option value="<?php echo htmlspecialchars($cdc); ?>"><?php echo htmlspecialchars($cdc); ?></option>
+                                <option value="<?php echo htmlspecialchars($cdc); ?>" <?php echo ($cdc == $centro_costo_selezionato) ? 'selected' : ''; ?>><?php echo htmlspecialchars($cdc); ?></option>
                             <?php endforeach; ?>
                         </select>
                     </div>
@@ -296,7 +333,7 @@ error_log("--- [{$timestamp}] Accesso a form_page.php UTENTE: " . htmlspecialcha
                 <input type="hidden" name="prodotti_json" id="prodotti_json">
 
                 <div class="main-form-actions">
-                    <button type="submit" id="submit-order-btn" class="action-button submit-order">Invia Richiesta</button> 
+                    <button type="submit" id="submit-order-btn" class="action-button submit-order">Salva Modifiche</button>
                 </div>
             </form>
         </main>
@@ -322,7 +359,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const addProductAdminBtn = document.getElementById('add-product-admin-btn');
     const newProductAdminInput = document.getElementById('new_product_admin');
     const newProductCategorySelect = document.getElementById('new_product_category');
-    let addedProductsArray = [];
+    let addedProductsArray = <?php echo json_encode($prodotti_esistenti, JSON_UNESCAPED_UNICODE); ?>;
 
     showProductFormBtn.addEventListener('click', function() {
         productEntryForm.style.display = 'block';

--- a/CRM/gestioneordini.php
+++ b/CRM/gestioneordini.php
@@ -27,6 +27,7 @@ $filtro_data_a = isset($_GET['data_a']) ? $_GET['data_a'] : '';
 $conn_go = isset($db_port) ? new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port) : new mysqli($db_host, $db_user, $db_pass, $db_name);
 $ordini_dal_db = [];
 $chat_messaggi = [];
+$ordini_modifiche = [];
 $db_error_message_go = null;
 $totale_ordini = 0;
 
@@ -62,7 +63,7 @@ if ($conn_go->connect_error) {
         $offset = ($pagina_corrente - 1) * $ordini_per_pagina;
     }
 
-    $sql_base = "SELECT id_ordine, data_richiesta, nome_richiedente, centro_costo, stato_ordine FROM ordini" . $sql_where_clause;
+    $sql_base = "SELECT id_ordine, data_richiesta, nome_richiedente, centro_costo, stato_ordine, consenti_modifica FROM ordini" . $sql_where_clause;
     $sql_base .= " ORDER BY CASE stato_ordine WHEN 'Inviato' THEN 1 WHEN 'In Lavorazione' THEN 2 WHEN 'Approvato Parzialmente' THEN 3 WHEN 'Approvato' THEN 4 WHEN 'Rifiutato' THEN 5 WHEN 'Evaso' THEN 6 ELSE 7 END, data_richiesta DESC";
     $sql_base .= " LIMIT ? OFFSET ?";
 
@@ -108,6 +109,21 @@ if ($conn_go->connect_error) {
                 $res_chat->free();
             }
             $stmt_chat->close();
+
+            // Carica anche le modifiche registrate
+            $types_mod = str_repeat('i', count($ids));
+            $sql_mod = "SELECT id_ordine, prima, dopo, data_modifica FROM ordini_modifiche WHERE id_ordine IN ($placeholders) ORDER BY data_modifica ASC";
+            $stmt_mod = $conn_go->prepare($sql_mod);
+            $stmt_mod->bind_param($types_mod, ...$ids);
+            $stmt_mod->execute();
+            $res_mod = $stmt_mod->get_result();
+            if ($res_mod) {
+                while ($row = $res_mod->fetch_assoc()) {
+                    $ordini_modifiche[$row['id_ordine']][] = $row;
+                }
+                $res_mod->free();
+            }
+            $stmt_mod->close();
         }
     } else {
         $db_error_message_go = "Errore durante la preparazione degli ordini.";
@@ -308,6 +324,11 @@ if ($conn_go->connect_error) {
                             </div>
                             <div class="order-details">
                                 <h4>Dettaglio Prodotti:</h4>
+                                <?php if ($ordine['consenti_modifica'] == 0 && $ordine['stato_ordine'] !== 'Evaso'): ?>
+                                    <button type="button" class="admin-button small unlock-order-btn" data-order-id="<?php echo $ordine['id_ordine']; ?>">Sblocca per Modifica</button>
+                                <?php elseif ($ordine['consenti_modifica'] == 1): ?>
+                                    <p style="color:#0d6efd;font-weight:bold;">Ordine modificabile dall'utente.</p>
+                                <?php endif; ?>
                                 <?php if (!empty($ordine['prodotti'])): ?>
                                     <?php foreach ($ordine['prodotti'] as $prodotto): ?>
                                         <div class="product-detail-item" data-product-id="<?php echo $prodotto['id_dettaglio_ordine']; ?>">
@@ -336,7 +357,7 @@ if ($conn_go->connect_error) {
                                     <p>Nessun prodotto in questo ordine.</p>
                                 <?php endif; ?>
 
-                                <?php if (!empty($chat_messaggi[$ordine['id_ordine']])): ?>
+                               <?php if (!empty($chat_messaggi[$ordine['id_ordine']])): ?>
                                     <div class="chat-messages">
                                         <?php foreach ($chat_messaggi[$ordine['id_ordine']] as $msg): ?>
                                             <div class="chat-message admin">
@@ -352,7 +373,22 @@ if ($conn_go->connect_error) {
                                                         <time><?php echo date('d/m H:i', strtotime($msg['data_risposta'])); ?></time>
                                                     </div>
                                                 </div>
-                                            <?php endif; ?>
+                               <?php endif; ?>
+
+                                <?php if (!empty($ordini_modifiche[$ordine['id_ordine']])): ?>
+                                    <div class="order-modifications" style="margin-top:10px;">
+                                        <h5>Modifiche effettuate:</h5>
+                                        <ul>
+                                            <?php foreach ($ordini_modifiche[$ordine['id_ordine']] as $mod): ?>
+                                                <li>
+                                                    <em><?php echo date('d/m/Y H:i', strtotime($mod['data_modifica'])); ?></em><br>
+                                                    <strong>Prima:</strong> <?php echo htmlspecialchars($mod['prima']); ?><br>
+                                                    <strong>Dopo:</strong> <?php echo htmlspecialchars($mod['dopo']); ?>
+                                                </li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    </div>
+                                <?php endif; ?>
                                         <?php endforeach; ?>
                                     </div>
                                 <?php endif; ?>
@@ -424,6 +460,11 @@ document.addEventListener('DOMContentLoaded', function() {
             if (target.classList.contains('product-action-btn') || target.classList.contains('edit-status-btn')) {
                 event.stopPropagation(); // Evita che il click si propaghi e chiuda/apra l'ordine
                 handleProductAction(target);
+            }
+
+            if (target.classList.contains('unlock-order-btn')) {
+                event.stopPropagation();
+                unlockOrder(target);
             }
 
             const chatBtn = target.closest('.update-chat-btn');
@@ -507,6 +548,26 @@ document.addEventListener('DOMContentLoaded', function() {
             orderStatusBadge.textContent = newOrderStatus;
             orderStatusBadge.className = 'status-badge ' + newOrderStatus.toLowerCase().replace(/ /g, '-');
         }
+    }
+
+    function unlockOrder(button) {
+        const orderId = button.dataset.orderId;
+        button.textContent = '...';
+        button.disabled = true;
+        const fd = new FormData();
+        fd.append('id_ordine', orderId);
+        fetch('unlock_order_action.php', { method: 'POST', body: fd })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    button.outerHTML = '<p style="color:#0d6efd;font-weight:bold;">Ordine modificabile dall\'utente.</p>';
+                } else {
+                    alert(data.message);
+                    button.textContent = 'Sblocca per Modifica';
+                    button.disabled = false;
+                }
+            })
+            .catch(() => { alert('Errore di rete.'); button.textContent = 'Sblocca per Modifica'; button.disabled = false; });
     }
 
     function handleChatSubmit(button) {

--- a/CRM/gestioneprodotti.php
+++ b/CRM/gestioneprodotti.php
@@ -1,0 +1,182 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+// Solo admin
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || ($_SESSION['ruolo'] ?? '') !== 'admin') {
+    header("Location: login.php");
+    exit;
+}
+
+$success_message = $_SESSION['catalogo_success'] ?? '';
+$error_message = $_SESSION['catalogo_error'] ?? '';
+unset($_SESSION['catalogo_success'], $_SESSION['catalogo_error']);
+
+$conn = isset($db_port)
+    ? new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port)
+    : new mysqli($db_host, $db_user, $db_pass, $db_name);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['nome_categoria'])) {
+        $nome_cat = trim($_POST['nome_categoria']);
+        if ($nome_cat === '') {
+            $_SESSION['catalogo_error'] = "Nome categoria mancante.";
+        } elseif ($conn->connect_error) {
+            $_SESSION['catalogo_error'] = "Errore connessione database.";
+        } else {
+            $stmt = $conn->prepare("INSERT INTO categorie_prodotti (nome) VALUES (?)");
+            if ($stmt) {
+                $stmt->bind_param('s', $nome_cat);
+                if ($stmt->execute()) {
+                    $_SESSION['catalogo_success'] = "Categoria aggiunta con successo.";
+                } else {
+                    $_SESSION['catalogo_error'] = $conn->errno == 1062 ? "Categoria già esistente." : "Errore durante l'inserimento.";
+                }
+                $stmt->close();
+            } else {
+                $_SESSION['catalogo_error'] = "Errore preparazione statement.";
+            }
+        }
+    } elseif (isset($_POST['nome_prodotto'])) {
+        $nome = trim($_POST['nome_prodotto']);
+        $categoria_id = isset($_POST['categoria_id']) ? (int)$_POST['categoria_id'] : 1;
+        if ($nome === '') {
+            $_SESSION['catalogo_error'] = "Nome prodotto mancante.";
+        } elseif ($conn->connect_error) {
+            $_SESSION['catalogo_error'] = "Errore connessione database.";
+        } else {
+            $stmt = $conn->prepare("INSERT INTO catalogo_prodotti (nome, categoria_id) VALUES (?, ?)");
+            if ($stmt) {
+                $stmt->bind_param('si', $nome, $categoria_id);
+                if ($stmt->execute()) {
+                    $_SESSION['catalogo_success'] = "Prodotto aggiunto con successo.";
+                } else {
+                    $_SESSION['catalogo_error'] = $conn->errno == 1062 ? "Prodotto già esistente." : "Errore durante l'inserimento.";
+                }
+                $stmt->close();
+            } else {
+                $_SESSION['catalogo_error'] = "Errore preparazione statement.";
+            }
+        }
+    }
+    $conn->close();
+    header("Location: gestioneprodotti.php");
+    exit;
+}
+
+$categorie = [];
+$prodotti = [];
+if (!$conn->connect_error) {
+    $res = $conn->query("SELECT id, nome FROM categorie_prodotti ORDER BY nome ASC");
+    if ($res) {
+        while ($row = $res->fetch_assoc()) {
+            $categorie[] = $row;
+        }
+        $res->free();
+    }
+    $res = $conn->query("SELECT p.id, p.nome, c.nome AS categoria FROM catalogo_prodotti p JOIN categorie_prodotti c ON p.categoria_id=c.id ORDER BY c.nome ASC, p.nome ASC");
+    if ($res) {
+        while ($row = $res->fetch_assoc()) {
+            $prodotti[] = $row;
+        }
+        $res->free();
+    }
+}
+$conn->close();
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestione Prodotti</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body { background-color: #f8f9fa; color: #495057; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; line-height: 1.6; }
+        .page-outer-container { max-width: 900px; margin: 25px auto; padding: 0; animation: fadeInSlideUp 0.6s ease-out forwards; }
+        .module-header { display: flex; justify-content: space-between; align-items: center; background-color: #ffffff; padding: 18px 30px; border-radius: 8px; box-shadow: 0 3px 10px rgba(0,0,0,0.05); border-bottom: 4px solid #B08D57; margin-bottom: 30px; }
+        .header-branding { display: flex; align-items: center; }
+        .header-branding .logo { max-height: 45px; margin-right: 15px; }
+        .header-titles h1 { font-size: 1.5em; color: #2E572E; margin: 0; font-weight: 600; }
+        .header-titles h2 { font-size: 0.9em; color: #6c757d; margin: 0; font-weight: 400; }
+        .user-session-controls { display: flex; align-items: center; gap: 15px; }
+        .user-session-controls .nav-link-button, .user-session-controls .logout-button { padding: 7px 14px; font-size: 0.9em; color: white !important; text-decoration: none; border-radius: 5px; transition: background-color 0.2s ease, transform 0.2s ease; font-weight: 500; }
+        .user-session-controls .nav-link-button { background-color: #6c757d; }
+        .user-session-controls .nav-link-button:hover { background-color: #5a6268; transform: translateY(-1px); }
+        .user-session-controls .logout-button { background-color: #D42A2A; }
+        .user-session-controls .logout-button:hover { background-color: #c82333; transform: translateY(-1px); }
+        .module-content { background-color: #ffffff; padding: 25px 30px; border-radius: 8px; box-shadow: 0 3px 10px rgba(0,0,0,0.05); }
+        table.catalogo-table { width: 100%; border-collapse: collapse; margin-top: 20px; font-size: 0.95em; }
+        .catalogo-table th, .catalogo-table td { border: 1px solid #dee2e6; padding: 12px 15px; text-align: left; }
+        .catalogo-table th { background-color: #f8f9fa; font-weight: 600; }
+        .feedback-message { margin-bottom: 20px; padding: 12px 15px; border-radius: 5px; font-weight: 500; text-align: center; }
+        .feedback-message.success { color: #0f5132; background-color: #d1e7dd; border: 1px solid #badbcc; }
+        .feedback-message.error { color: #842029; background-color: #f8d7da; border: 1px solid #f5c2c7; }
+    </style>
+</head>
+<body>
+    <div class="page-outer-container">
+        <header class="module-header">
+            <div class="header-branding">
+                <a href="dashboard.php"><img src="logo.png" alt="Logo Gruppo Vitolo" class="logo"></a>
+                <div class="header-titles">
+                    <h1>Gestione Prodotti</h1>
+                    <h2>Catalogo</h2>
+                </div>
+            </div>
+            <div class="user-session-controls">
+                <a href="dashboard.php" class="nav-link-button">Dashboard</a>
+                <a href="logout.php" class="logout-button">Logout</a>
+            </div>
+        </header>
+        <main class="module-content">
+            <?php if ($success_message): ?>
+                <div class="feedback-message success"><?php echo htmlspecialchars($success_message); ?></div>
+            <?php elseif ($error_message): ?>
+                <div class="feedback-message error"><?php echo htmlspecialchars($error_message); ?></div>
+            <?php endif; ?>
+            <form method="POST" action="gestioneprodotti.php" style="margin-bottom:20px;">
+                <h3>Aggiungi Nuova Categoria</h3>
+                <div class="form-group">
+                    <label for="nome_categoria">Nome categoria:</label>
+                    <input type="text" id="nome_categoria" name="nome_categoria" required>
+                </div>
+                <button type="submit" class="admin-button">Aggiungi Categoria</button>
+            </form>
+
+            <form method="POST" action="gestioneprodotti.php">
+                <h3>Aggiungi Nuovo Prodotto</h3>
+                <div class="form-group">
+                    <label for="nome_prodotto">Nome prodotto:</label>
+                    <input type="text" id="nome_prodotto" name="nome_prodotto" required>
+                </div>
+                <div class="form-group">
+                    <label for="categoria_id">Categoria:</label>
+                    <select id="categoria_id" name="categoria_id">
+                        <?php foreach ($categorie as $cat): ?>
+                            <option value="<?php echo $cat['id']; ?>"><?php echo htmlspecialchars($cat['nome']); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <button type="submit" class="admin-button">Aggiungi Prodotto</button>
+            </form>
+            <table class="catalogo-table">
+                <thead>
+                    <tr><th>ID</th><th>Nome</th><th>Categoria</th></tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($prodotti as $p): ?>
+                        <tr><td><?php echo $p['id']; ?></td><td><?php echo htmlspecialchars($p['nome']); ?></td><td><?php echo htmlspecialchars($p['categoria']); ?></td></tr>
+                    <?php endforeach; ?>
+                    <?php if (empty($prodotti)): ?>
+                        <tr><td colspan="3" style="text-align:center;">Nessun prodotto presente.</td></tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </main>
+        <footer class="footer-logo-area">
+            <img src="logo.png" alt="Logo Gruppo Vitolo">
+        </footer>
+    </div>
+</body>
+</html>

--- a/CRM/i_miei_ordini.php
+++ b/CRM/i_miei_ordini.php
@@ -24,7 +24,7 @@ if ($conn->connect_error) {
     $db_error_message = "Impossibile connettersi al database per caricare lo storico.";
 } else {
     // 1. Prendi tutti gli ordini creati dall'utente loggato
-    $sql_ordini = "SELECT id_ordine, data_richiesta, centro_costo, stato_ordine, fattura_file
+    $sql_ordini = "SELECT id_ordine, data_richiesta, centro_costo, stato_ordine, consenti_modifica, fattura_file
                    FROM ordini
                    WHERE id_utente_richiedente = ?
                    ORDER BY data_richiesta DESC";
@@ -176,6 +176,9 @@ if ($conn->connect_error) {
                                     <span class="status-badge <?php echo $status_class; ?>">
                                         <?php echo htmlspecialchars($ordine['stato_ordine']); ?>
                                     </span>
+                                    <?php if ($ordine['consenti_modifica'] == 1): ?>
+                                        <a href="edit_order.php?id=<?php echo $ordine['id_ordine']; ?>" class="nav-link-button" style="margin-left:10px;">Modifica</a>
+                                    <?php endif; ?>
                                 </div>
                             </div>
                             <div class="order-details">

--- a/CRM/unlock_order_action.php
+++ b/CRM/unlock_order_action.php
@@ -1,0 +1,56 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+header('Content-Type: application/json');
+$response = ['success' => false, 'message' => 'Errore sconosciuto'];
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $response['message'] = 'Metodo di richiesta non valido.';
+    echo json_encode($response);
+    exit;
+}
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || ($_SESSION['ruolo'] ?? '') !== 'admin') {
+    $response['message'] = 'Accesso non autorizzato.';
+    echo json_encode($response);
+    exit;
+}
+
+$id_ordine = filter_input(INPUT_POST, 'id_ordine', FILTER_VALIDATE_INT);
+if (!$id_ordine) {
+    $response['message'] = 'ID ordine non valido.';
+    echo json_encode($response);
+    exit;
+}
+
+$conn = isset($db_port)
+    ? new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port)
+    : new mysqli($db_host, $db_user, $db_pass, $db_name);
+
+if ($conn->connect_error) {
+    $response['message'] = 'Errore di connessione al database.';
+    echo json_encode($response);
+    exit;
+}
+
+$stmt = $conn->prepare("UPDATE ordini SET consenti_modifica = 1 WHERE id_ordine = ? AND consenti_modifica = 0");
+if ($stmt) {
+    $stmt->bind_param('i', $id_ordine);
+    $stmt->execute();
+    if ($stmt->affected_rows > 0) {
+        $response['success'] = true;
+        $response['message'] = 'Ordine sbloccato per modifica.';
+    } else {
+        $response['message'] = 'Ordine già modificabile o non trovato.';
+    }
+    $stmt->close();
+} else {
+    $response['message'] = 'Errore preparazione statement.';
+}
+
+$conn->close();
+
+echo json_encode($response);
+exit;
+?>

--- a/CRM/update_order_action.php
+++ b/CRM/update_order_action.php
@@ -1,0 +1,85 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || !isset($_SESSION['user_id'])) {
+    header('Location: i_miei_ordini.php?edit=error');
+    exit;
+}
+
+$id_ordine = filter_input(INPUT_POST, 'id_ordine', FILTER_VALIDATE_INT);
+$prodotti_json = $_POST['prodotti_json'] ?? '[]';
+$prodotti = json_decode($prodotti_json, true);
+
+if (!$id_ordine || empty($prodotti) || !is_array($prodotti)) {
+    header('Location: i_miei_ordini.php?edit=error');
+    exit;
+}
+
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+if ($conn->connect_error) {
+    header('Location: i_miei_ordini.php?edit=error');
+    exit;
+}
+
+$conn->begin_transaction();
+try {
+    $stmt_check = $conn->prepare('SELECT id_utente_richiedente, consenti_modifica FROM ordini WHERE id_ordine = ?');
+    $stmt_check->bind_param('i', $id_ordine);
+    $stmt_check->execute();
+    $info = $stmt_check->get_result()->fetch_assoc();
+    $stmt_check->close();
+
+    if (!$info || $info['id_utente_richiedente'] != $_SESSION['user_id'] || $info['consenti_modifica'] != 1) {
+        throw new Exception('Ordine non modificabile.');
+    }
+
+    $stmt_old = $conn->prepare('SELECT nome_prodotto, quantita, unita_misura, note_prodotto FROM dettagli_ordine WHERE id_ordine = ? ORDER BY id_dettaglio_ordine');
+    $stmt_old->bind_param('i', $id_ordine);
+    $stmt_old->execute();
+    $old_data = $stmt_old->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt_old->close();
+
+    $stmt_del = $conn->prepare('DELETE FROM dettagli_ordine WHERE id_ordine = ?');
+    $stmt_del->bind_param('i', $id_ordine);
+    $stmt_del->execute();
+    $stmt_del->close();
+
+    $stmt_ins = $conn->prepare('INSERT INTO dettagli_ordine (id_ordine, nome_prodotto, quantita, unita_misura, note_prodotto, stato_prodotto) VALUES (?, ?, ?, ?, ?, "Inviato")');
+    if (!$stmt_ins) throw new Exception('Errore preparazione insert.');
+    foreach ($prodotti as $p) {
+        $nome = trim($p['name'] ?? '');
+        $qta = (int)($p['quantity'] ?? 0);
+        $um = trim($p['unit'] ?? '');
+        $note = trim($p['notes'] ?? '');
+        if ($nome === '' || $qta <= 0 || $um === '') {
+            throw new Exception('Dati prodotto non validi.');
+        }
+        $stmt_ins->bind_param('isiss', $id_ordine, $nome, $qta, $um, $note);
+        $stmt_ins->execute();
+    }
+    $stmt_ins->close();
+
+    $stmt_upd = $conn->prepare('UPDATE ordini SET consenti_modifica = 0, stato_ordine = "Inviato", data_ultima_modifica = CURRENT_TIMESTAMP WHERE id_ordine = ?');
+    $stmt_upd->bind_param('i', $id_ordine);
+    $stmt_upd->execute();
+    $stmt_upd->close();
+
+    $stmt_mod = $conn->prepare('INSERT INTO ordini_modifiche (id_ordine, id_utente, prima, dopo) VALUES (?, ?, ?, ?)');
+    $old_json = json_encode($old_data, JSON_UNESCAPED_UNICODE);
+    $new_json = json_encode($prodotti, JSON_UNESCAPED_UNICODE);
+    $stmt_mod->bind_param('iiss', $id_ordine, $_SESSION['user_id'], $old_json, $new_json);
+    $stmt_mod->execute();
+    $stmt_mod->close();
+
+    $conn->commit();
+    $conn->close();
+    header('Location: i_miei_ordini.php?edit=success');
+    exit;
+} catch (Exception $e) {
+    $conn->rollback();
+    $conn->close();
+    header('Location: i_miei_ordini.php?edit=error');
+    exit;
+}
+?>


### PR DESCRIPTION
## Summary
- create `categorie_prodotti` table and link to `catalogo_prodotti`
- extend admin pages to add categories and assign them to products
- group products by category in request and edit forms
- support adding products with category via AJAX

## Testing
- `php -l CRM/add_product_action.php` *(fails: php not installed)*
- `php -l CRM/gestioneprodotti.php` *(fails: php not installed)*
- `php -l CRM/form_page.php` *(fails: php not installed)*
- `php -l CRM/edit_order.php` *(fails: php not installed)*
- `php -l CRM/db_deploy.sql` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_b_6846e95f8bf0832d9cc9e4cf92954cc0